### PR TITLE
GitHub action to generate .tex and .pdf of .cgel trees in PR

### DIFF
--- a/.github/workflows/tex-pdf.yml
+++ b/.github/workflows/tex-pdf.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           submodules: true
       # https://github.com/Ana06/get-changed-files/releases/tag/v1.2
-      - uses: Ana06/get-changed-files@v2.3.0
+      - uses: Ana06/get-changed-files@25f79e676e7ea1868813e21465014798211fad8c
         id: files
         with:
           format: space-delimited
@@ -55,16 +55,15 @@ jobs:
           mkdir -p datasets/oneoff/pdf
           for changed_file in ${{ steps.files.outputs.added_modified }}; do
             if [[ "$changed_file" == **.cgel ]]; then
-              # make .tex
               filename=$(basename "$changed_file")
               tree_name="${filename%.cgel}"
-              python cgel/tree2tex.py ${changed_file} > datasets/oneoff/tex/$tree_name.tex
-              git add datasets/oneoff/tex/$tree_name.tex
-              git commit -m "generated tex file for $filename"
+              # make .tex
+              python cgel/tree2tex.py "${changed_file}" > datasets/oneoff/tex/"$tree_name".tex
+              git add datasets/oneoff/tex/"$tree_name".tex
               # make .pdf 
-              pdflatex -output-directory=datasets/oneoff/pdf datasets/oneoff/tex/$tree_name.tex
-              git add datasets/oneoff/pdf/$tree_name.pdf
-              git commit -m "generated pdf file for $filename"
+              pdflatex -output-directory=datasets/oneoff/pdf datasets/oneoff/tex/"$tree_name".tex
+              git add datasets/oneoff/pdf/"$tree_name".pdf
+              git commit -m "generated tex and pdf files for $filename"
             fi
           done   
           git push origin HEAD:${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/tex-pdf.yml
+++ b/.github/workflows/tex-pdf.yml
@@ -11,19 +11,26 @@ on:
 jobs:
   render:
     runs-on: ubuntu-latest
+    
+    permissions:
+      contents: write
+      
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          
       # https://github.com/Ana06/get-changed-files/releases/tag/v1.2
       - uses: Ana06/get-changed-files@25f79e676e7ea1868813e21465014798211fad8c
         id: files
         with:
           format: space-delimited
-          token: ${{ secrets.GITHUB_TOKEN }}
-
+          
       - name: Check out the pull request
-        run: gh pr checkout ${{ github.event.pull_request.number }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          gh pr checkout ${{ github.event.pull_request.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -34,12 +41,8 @@ jobs:
 
       - name: Install cgel dependencies
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           python -m pip install --upgrade pip
           pip install -r cgel/requirements.txt
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install texlive
         run: sudo apt-get install texlive-latex-extra

--- a/.github/workflows/tex-pdf.yml
+++ b/.github/workflows/tex-pdf.yml
@@ -1,0 +1,72 @@
+# add .tex conversion and (and .pdf rendering of .tex file) to a pull request that adds/modifies a cgel tree.
+# currently assumes cgel file(s) in datasets/oneoff.
+
+name: Create tree .tex and .pdf 
+
+permissions:
+  contents: write
+  pull-requests: write
+  repository-projects: write
+
+on:
+  pull_request:
+    paths:
+      - datasets/oneoff/*.cgel
+
+jobs:
+  render:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      # https://github.com/Ana06/get-changed-files/releases/tag/v1.2
+      - uses: Ana06/get-changed-files@v2.3.0
+        id: files
+        with:
+          format: space-delimited
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check out the pull request
+        run: gh pr checkout ${{ github.event.pull_request.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+
+      - name: Install cgel dependencies
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          python -m pip install --upgrade pip
+          pip install -r cgel/requirements.txt
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install texlive
+        run: sudo apt-get install texlive-latex-extra
+          
+      - name: Generate .tex and .pdf files and commit
+        run: |
+          mkdir -p datasets/oneoff/tex
+          mkdir -p datasets/oneoff/pdf
+          for changed_file in ${{ steps.files.outputs.added_modified }}; do
+            if [[ "$changed_file" == **.cgel ]]; then
+              # make .tex
+              filename=$(basename "$changed_file")
+              tree_name="${filename%.cgel}"
+              python cgel/tree2tex.py ${changed_file} > datasets/oneoff/tex/$tree_name.tex
+              git add datasets/oneoff/tex/$tree_name.tex
+              git commit -m "generated tex file for $filename"
+              # make .pdf 
+              pdflatex -output-directory=datasets/oneoff/pdf datasets/oneoff/tex/$tree_name.tex
+              git add datasets/oneoff/pdf/$tree_name.pdf
+              git commit -m "generated pdf file for $filename"
+            fi
+          done   
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tex-pdf.yml
+++ b/.github/workflows/tex-pdf.yml
@@ -3,11 +3,6 @@
 
 name: Create tree .tex and .pdf 
 
-permissions:
-  contents: write
-  pull-requests: write
-  repository-projects: write
-
 on:
   pull_request:
     paths:

--- a/.github/workflows/tex-pdf.yml
+++ b/.github/workflows/tex-pdf.yml
@@ -58,11 +58,11 @@ jobs:
               filename=$(basename "$changed_file")
               tree_name="${filename%.cgel}"
               # make .tex
-              python cgel/tree2tex.py "${changed_file}" > datasets/oneoff/tex/"$tree_name".tex
-              git add datasets/oneoff/tex/"$tree_name".tex
+              python cgel/tree2tex.py "${changed_file}" > "datasets/oneoff/tex/$tree_name.tex"
+              git add "datasets/oneoff/tex/$tree_name.tex"
               # make .pdf 
-              pdflatex -output-directory=datasets/oneoff/pdf datasets/oneoff/tex/"$tree_name".tex
-              git add datasets/oneoff/pdf/"$tree_name".pdf
+              pdflatex -output-directory=datasets/oneoff/pdf "datasets/oneoff/tex/$tree_name.tex"
+              git add "datasets/oneoff/pdf/$tree_name.pdf"
               git commit -m "generated tex and pdf files for $filename"
             fi
           done   

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cgel"]
+	path = cgel
+	url = https://github.com/nert-nlp/cgel


### PR DESCRIPTION
Addresses https://github.com/nert-nlp/legal-cgel/pull/1#issuecomment-2233730181

When a contributor opens a PR that adds/modifies a .cgel tree file (or multiple .cgel tree files), this action calls `tree2tex.py` from the repo's `cgel` submodule and creates a `.tex` conversion for each .cgel file. The action then calls `pdflatex` to convert the `.tex` file(s) to pdf. The .tex and .pdf files are committed to the PR branch. 

One current drawback: texlive (and cgel-relevant python packages) must be installed by the GitHub-hosted virtual machine each time the action is run. The python packages install quickly, but it takes about a minute to download texlive. There may be a way to speed this up in the future by caching texlive: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows

I can also extend the action script so that it runs the CGEL validator prior to converting the tree(s).