### PR TITLE
Further constrain write permissions for github action

### DIFF
--- a/.github/workflows/tex-pdf.yml
+++ b/.github/workflows/tex-pdf.yml
@@ -12,7 +12,10 @@ on:
 jobs:
   render:
     runs-on: ubuntu-latest
-      
+
+    permissions:
+      contents: write
+    
     steps:
       - uses: actions/checkout@v4
         with:
@@ -45,7 +48,7 @@ jobs:
       - name: Install texlive
         run: sudo apt-get install texlive-latex-extra
           
-      - name: Generate .tex and .pdf files and commit
+      - name: Generate .tex and .pdf files
         run: |
           mkdir -p datasets/oneoff/tex
           mkdir -p datasets/oneoff/pdf
@@ -55,9 +58,18 @@ jobs:
               tree_name="${filename%.cgel}"
               # make .tex
               python cgel/tree2tex.py "${changed_file}" > "datasets/oneoff/tex/$tree_name.tex"
-              git add "datasets/oneoff/tex/$tree_name.tex"
               # make .pdf 
               pdflatex -output-directory=datasets/oneoff/pdf "datasets/oneoff/tex/$tree_name.tex"
+            fi
+          done   
+
+      - name: Commit and push .tex and .pdf files 
+        run: |
+          for changed_file in ${{ steps.files.outputs.added_modified }}; do
+            if [[ "$changed_file" == **.cgel ]]; then
+              filename=$(basename "$changed_file")
+              tree_name="${filename%.cgel}"
+              git add "datasets/oneoff/tex/$tree_name.tex"
               git add "datasets/oneoff/pdf/$tree_name.pdf"
               git commit -m "generated tex and pdf files for $filename"
             fi


### PR DESCRIPTION
Separates out file generation and repo commit/push into two steps. (Access token env variable is only set for the latter step, so that we're not executing python and texlive commands in a context w/ repo permissions).