### PR TITLE
Set action to perform on push to repo

### DIFF
--- a/.github/workflows/tex-pdf.yml
+++ b/.github/workflows/tex-pdf.yml
@@ -4,10 +4,9 @@
 name: Create tree .tex and .pdf 
 
 on:
-  pull_request:
+  push:
     paths:
       - datasets/oneoff/*.cgel
-    branches: [ "main" ]
 
 jobs:
   render:
@@ -19,6 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.ref }}
           submodules: true
           
       # https://github.com/Ana06/get-changed-files/releases/tag/v1.2
@@ -27,11 +27,10 @@ jobs:
         with:
           format: space-delimited
           
-      - name: Check out the pull request
+      - name: Config github actions bot
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          gh pr checkout ${{ github.event.pull_request.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -74,6 +73,6 @@ jobs:
               git commit -m "generated tex and pdf files for $filename"
             fi
           done   
-          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+          git push
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
An even safer (and more convenient) way to perform the GitHub action. 

**Before:** action was triggered when main branch detected a PR. Action checks out merge branch, installs dependencies specified on the merge branch (i.e., in merge branch's copy of `cgel/requirements.txt`), and executes code from the merge branch (e.g., the merge branch's copy of `cgel/tree2tex.py`). Action then commits files and pushes to the merge branch. 

This is unsafe, because the action has `write` permissions both for the base branch and the merge branch. So, malicious code from the merge branch could execute writes on `main`. 

This is also inconvenient: it means that .pdfs are generated only when the annotator has opened a PR.

**Now:** action is triggered 'locally,' when an annotator's branch detects a push involving a .cgel file. Action checks out the annotator's own branch, installs dependencies and runs code from that branch, and commits/pushes files to that branch. 

Safer: action only needs `write` permissions for the local branch. 

More convenient: pdfs are rendered whenever the annotator adds/modifies .cgel files on their branch. 