### PR TITLE
Update ANNOTATION_GUIDELINES.md

### DIFF
--- a/ANNOTATION_GUIDELINES.md
+++ b/ANNOTATION_GUIDELINES.md
@@ -11,8 +11,8 @@ A sentence may exhibit structural ambiguities that can't be resolved out of cont
 ... which has two plausible readings (each with a distinct CGELBank analysis):
 
 ```
-1. may [ [ request [ a review [ of such determination ] ] ] [ in a proceeding to remove the alien ] ]
-2. may [ request [ a review [ of such determination ] [ in a proceeding to remove the alien ] ] ]
+1. may [ request [ a review of such determination ] [ in a proceeding to remove the alien ] ] 
+2. may [ request [ a review [ of such determination ] [ in a proceeding to remove the alien ] ] ] 
 ```
 
 On reading (1), *the request* takes place in a removal proceeding. On reading (2), *the review* takes place in a removal proceeding. In CGELBank, these readings correspond to two possible attachment sites of the modifier PP *in a proceeding to remove the alien*. Note that there seems to be a much less plausible (though nonetheless possible) reading (3), in which *the determination* takes place in a removal proceeding:
@@ -25,7 +25,19 @@ Annotators can ignore (3)-like cases but should note when there are multiple pla
 
 - The annotator's CGELBank tree should reflect one of the plausible analyses.
 - In a `:note` tag on the tree, describe the ambiguity in enough detail that another reader could understand what is going on. **Make sure the string `[AMBIG]` appears somewhere in the tag.**
-- If the annotator believes that not all plausible analyses are *equally* plausible, add this to the `:note` tag with a brief explanation. (In this case, the annotator's tree should ideally reflect what the annotator takes to be the *most* plausible analysis). 
+- If the annotator believes that not all plausible analyses are *equally* plausible, add this to the `:note` tag with a brief explanation. (In this case, the annotator's tree should ideally reflect what the annotator takes to be the *most* plausible analysis).
+
+### Exception: structural ambiguities that don't reflect distinct readings
+
+Even if a sentence is consistent with multiple possible syntactic analyses, the readings associated with those analyses may be highly similar to one another. Consider, e.g.:
+
+```
+1. shall [ [ be enforced in United States courts ] [ in accordance with this chapter ] ]
+2. shall [ be [ enforced in United States courts ] [ in accordance with this chapter ] ]
+3. shall [ be [ enforced [ in United States courts ] [ in accordance with this chapter ] ] ]
+```
+
+Does the PP *in accordance with this subchapter* modify the modal *shall* (1), the auxiliary *be* (2), or the verb *enforced* (3)? It's not clear that these three resolutions of the PP attachment ambiguity give rise to appreciably distinct readings. In cases like this, the default strategy is to attach low (3), and there is no need to make note of the ambiguity. 
 
 ## Dealing with legal terms of art
 


### PR DESCRIPTION
- Add a note on default preference for low attachment (when syntactic ambiguity does not give rise to distinct readings). 
- Simplify bracketing in "removal proceeding" example 